### PR TITLE
Workflow improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,52 +35,72 @@ So, what do you get by using this project as a template for your project? Let's 
 ### For development on your computer
 
 1. Clone the repository to your computer and go to the `django-docker-template` directory:
-```console
-git clone https://github.com/amerkurev/django-docker-template.git
-cd django-docker-template
-```
+    ```console
+    git clone https://github.com/amerkurev/django-docker-template.git
+    cd django-docker-template
+    ```
 
 2. Build the Docker container image with Django:
-```console
-docker build -t django-docker-template:master .
-```
+    ```console
+    docker build -t django-docker-template:master .
+    ```
 
 3. Run the Django development server inside the Django container:
-```console
-docker run -it --rm -p 8000:8000 -v sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
-```
+    ```console
+    docker run -it --rm -p 8000:8000 -v sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
+    ```
 
-Now you can go to http://127.0.0.1:8000/admin/ in your browser. The superuser with the login and password `admin/admin` is already created. Go to the Django admin panel and try updating the server code "on the fly." Everything works just like if you were running the Django development server outside the container.
-
-> Note that we mount the directory with your source code inside the container, so you can work with the project in your IDE, and changes will be visible inside the container, and the Django development server will restart itself. 
->
-> Another important point is the use of SQLite3 instead of Postgres (which we don't run). In our example, we add a volume named `sqlite`. This data is stored persistently and does not disappear between restarts of the Django development server. However, if you have a second similar project, it would be better to change the volume name from `sqlite` to something else so that the second project uses its own copy of the database. For example:
->
->```console
->docker run -it --rm -p 8000:8000 -v another_sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
->```
->
-> To better understand how volumes work in Docker, refer to the official [documentation](https://docs.docker.com/storage/volumes/).
+    Now you can go to http://127.0.0.1:8000/admin/ in your browser. The superuser with the login and password `admin/admin` is already created. Go to the Django admin panel and try updating the server code "on the fly." Everything works just like if you were running the Django development server outside the container.
+    
+    > Note that we mount the directory with your source code inside the container, so you can work with the project in your IDE, and changes will be visible inside the container, and the Django development server will restart itself. 
+    >
+    > Another important point is the use of SQLite3 instead of Postgres (which we don't run). In our example, we add a volume named `sqlite`. This data is stored persistently and does not disappear between restarts of the Django development server. However, if you have a second similar project, it would be better to change the volume name from `sqlite` to something else so that the second project uses its own copy of the database. For example:
+    >
+    >```console
+    >docker run -it --rm -p 8000:8000 -v another_sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
+    >```
+    >
+    > To better understand how volumes work in Docker, refer to the official [documentation](https://docs.docker.com/storage/volumes/).
 
 4. Run tests:
-```console
-docker run -it --rm django-docker-template:master python manage.py test polls
-```
+    ```console
+    docker run -it --rm django-docker-template:master python manage.py test polls
+    ```
 
 5. Interactive shell with the Django project environment:
-```console
-docker run -it --rm -v sqlite:/sqlite django-docker-template:master python manage.py shell
-```
+    ```console
+    docker run -it --rm -v sqlite:/sqlite django-docker-template:master python manage.py shell
+    ```
 
 6. Start all services locally (Postgres, Gunicorn, Traefik) using docker-compose:
-```console
-docker compose -f docker-compose.debug.yml up -d --build
-```
+    ```console
+    docker compose -f docker-compose.debug.yml up
+    ```
 
-Enjoy watching the lines run in the terminal 🖥️   
-And after a few seconds, open your browser at http://127.0.0.1/admin/. The first user already exists, welcome to the Django admin panel.
+    Enjoy watching the lines run in the terminal 🖥️   
+    And after a few seconds, open your browser at http://127.0.0.1/admin/. The first user already exists, welcome to the Django admin panel.
+    
+    Django is still in Debug mode! You can work in your IDE, write code, and immediately see changes inside the container. However, you are currently using Traefik and Postgres. You can also add Redis or MongoDB, and all of this will work in your development environment. This is very convenient.
+    
+    > Between Docker Compose restarts, your database data and media files uploaded to the server will be preserved because they are stored in special volumes that are not deleted when containers are restarted.
+    
+    Want to delete everything? No problem, the command below will stop all containers, remove them and their images.
+    ```console
+    docker compose down --remove-orphans --rmi local
+    ```
+    
+    To delete the Postgre database as well, add the `-v` flag to the command:
+    ```console
+    docker compose down --remove-orphans --rmi local -v
+    ```
 
-### More development commands
+### Django settings
+
+Some Django settings from the [`settings.py`](https://github.com/amerkurev/django-docker-template/blob/master/website/website/settings.py) file are stored in environment variables. You can easily change these settings in the [`.env`](https://github.com/amerkurev/django-docker-template/blob/master/.env) file. This file does not contain all the necessary settings, but many of them. Add additional settings to environment variables if needed. 
+
+> It is important to note the following: **never store sensitive settings such as DJANGO_SECRET_KEY or DJANGO_EMAIL_HOST_PASSWORD in your repository!** Docker allows you to override environment variable values from additional files, the command line, or the current session. Store passwords and other sensitive information separately from the code and only connect this information at system startup.
+
+#### More development commands
 
 With the containers running, you can run manage.py commands using this format:
 
@@ -88,42 +108,10 @@ With the containers running, you can run manage.py commands using this format:
  ```console
  docker-compose exec django python manage.py test
  ```
-- Make migrations
- ```console
- docker-compose exec django python manage.py makemigrations
- ```
-- Create superuser
- ```console
- docker-compose exec django python manage.py createsuperuser
- ```
 - Access the Django shell
  ```console
  docker-compose exec django python manage.py shell
  ```
-- Check the project for deployment issues
- ```console
- docker-compose exec django python manage.py check --deploy
- ```
-
-Django is still in Debug mode! You can work in your IDE, write code, and immediately see changes inside the container. However, you are currently using Traefik and Postgres. You can also add Redis or MongoDB, and all of this will work in your development environment. This is very convenient.
-
-> Between Docker Compose restarts, your database data and media files uploaded to the server will be preserved because they are stored in special volumes that are not deleted when containers are restarted.
-
-Want to delete everything? No problem, the command below will stop all containers, remove them and their images.
-```console
-docker compose down --remove-orphans --rmi local
-```
-
-To delete the Postgre database as well, add the `-v` flag to the command:
-```console
-docker compose down --remove-orphans --rmi local -v
-```
-
-#### Django settings
-
-Some Django settings from the [`settings.py`](https://github.com/amerkurev/django-docker-template/blob/master/website/website/settings.py) file are stored in environment variables. You can easily change these settings in the [`.env`](https://github.com/amerkurev/django-docker-template/blob/master/.env) file. This file does not contain all the necessary settings, but many of them. Add additional settings to environment variables if needed. 
-
-> It is important to note the following: **never store sensitive settings such as DJANGO_SECRET_KEY or DJANGO_EMAIL_HOST_PASSWORD in your repository!** Docker allows you to override environment variable values from additional files, the command line, or the current session. Store passwords and other sensitive information separately from the code and only connect this information at system startup.
 
 ### For deployment on a server
 
@@ -136,17 +124,17 @@ For the Let's Encrypt HTTP challenge you will need:
 #### Steps on a server
 
 1. Clone the repository on your host and go to the `django-docker-template` directory:
-```console
-git clone https://github.com/amerkurev/django-docker-template.git
-cd django-docker-template
-```
+    ```console
+    git clone https://github.com/amerkurev/django-docker-template.git
+    cd django-docker-template
+    ```
 
 2. Configure as described in the [Django settings](#django-settings) section or leave everything as is.
 
 3. Run, specifying your domain:
-```console
-MY_DOMAIN=your.domain.com docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
-```
+    ```console
+    MY_DOMAIN=your.domain.com docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+    ```
 
 It will take a few seconds to start the database, migrate, collect static files, and obtain a Let's Encrypt certificate. So wait a little and open https://your.domain.com in your browser. Your server is ready to work 🏆 
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,15 @@ docker run -it --rm -v sqlite:/sqlite django-docker-template:master python manag
 
 6. Start all services locally (Postgres, Gunicorn, Traefik) using docker-compose:
 ```console
-docker compose -f docker-compose.debug.yml up -d
+docker compose -f docker-compose.debug.yml up -d --build
 ```
 
 Enjoy watching the lines run in the terminal 🖥️   
 And after a few seconds, open your browser at http://127.0.0.1/admin/. The first user already exists, welcome to the Django admin panel.
 
-7. With the containers running, you can run manage.py commands using this format:
+### More development commands
+
+With the containers running, you can run manage.py commands using this format:
 
 - Run test suite
  ```console

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ To delete the Postgre database as well, add the `-v` flag to the command:
 docker compose down --remove-orphans --rmi local -v
 ```
 
-### Django settings
+#### Django settings
 
 Some Django settings from the [`settings.py`](https://github.com/amerkurev/django-docker-template/blob/master/website/website/settings.py) file are stored in environment variables. You can easily change these settings in the [`.env`](https://github.com/amerkurev/django-docker-template/blob/master/.env) file. This file does not contain all the necessary settings, but many of them. Add additional settings to environment variables if needed. 
 

--- a/README.md
+++ b/README.md
@@ -35,64 +35,64 @@ So, what do you get by using this project as a template for your project? Let's 
 ### For development on your computer
 
 1. Clone the repository to your computer and go to the `django-docker-template` directory:
-    ```console
-    git clone https://github.com/amerkurev/django-docker-template.git
-    cd django-docker-template
-    ```
+```console
+git clone https://github.com/amerkurev/django-docker-template.git
+cd django-docker-template
+```
 
 2. Build the Docker container image with Django:
-    ```console
-    docker build -t django-docker-template:master .
-    ```
+```console
+docker build -t django-docker-template:master .
+```
 
 3. Run the Django development server inside the Django container:
-    ```console
-    docker run -it --rm -p 8000:8000 -v sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
-    ```
+```console
+docker run -it --rm -p 8000:8000 -v sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
+```
 
-    Now you can go to http://127.0.0.1:8000/admin/ in your browser. The superuser with the login and password `admin/admin` is already created. Go to the Django admin panel and try updating the server code "on the fly." Everything works just like if you were running the Django development server outside the container.
-    
-    > Note that we mount the directory with your source code inside the container, so you can work with the project in your IDE, and changes will be visible inside the container, and the Django development server will restart itself. 
-    >
-    > Another important point is the use of SQLite3 instead of Postgres (which we don't run). In our example, we add a volume named `sqlite`. This data is stored persistently and does not disappear between restarts of the Django development server. However, if you have a second similar project, it would be better to change the volume name from `sqlite` to something else so that the second project uses its own copy of the database. For example:
-    >
-    >```console
-    >docker run -it --rm -p 8000:8000 -v another_sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
-    >```
-    >
-    > To better understand how volumes work in Docker, refer to the official [documentation](https://docs.docker.com/storage/volumes/).
+Now you can go to http://127.0.0.1:8000/admin/ in your browser. The superuser with the login and password `admin/admin` is already created. Go to the Django admin panel and try updating the server code "on the fly." Everything works just like if you were running the Django development server outside the container.
+
+> Note that we mount the directory with your source code inside the container, so you can work with the project in your IDE, and changes will be visible inside the container, and the Django development server will restart itself. 
+>
+> Another important point is the use of SQLite3 instead of Postgres (which we don't run). In our example, we add a volume named `sqlite`. This data is stored persistently and does not disappear between restarts of the Django development server. However, if you have a second similar project, it would be better to change the volume name from `sqlite` to something else so that the second project uses its own copy of the database. For example:
+>
+>```console
+>docker run -it --rm -p 8000:8000 -v another_sqlite:/sqlite -v $(pwd)/website:/usr/src/website django-docker-template:master python manage.py runserver 0.0.0.0:8000
+>```
+>
+> To better understand how volumes work in Docker, refer to the official [documentation](https://docs.docker.com/storage/volumes/).
 
 4. Run tests:
-    ```console
-    docker run -it --rm django-docker-template:master python manage.py test polls
-    ```
+```console
+docker run -it --rm django-docker-template:master python manage.py test polls
+```
 
 5. Interactive shell with the Django project environment:
-    ```console
-    docker run -it --rm -v sqlite:/sqlite django-docker-template:master python manage.py shell
-    ```
+```console
+docker run -it --rm -v sqlite:/sqlite django-docker-template:master python manage.py shell
+```
 
 6. Start all services locally (Postgres, Gunicorn, Traefik) using docker-compose:
-    ```console
-    docker compose -f docker-compose.debug.yml up
-    ```
+```console
+docker compose -f docker-compose.debug.yml up
+```
 
-    Enjoy watching the lines run in the terminal 🖥️   
-    And after a few seconds, open your browser at http://127.0.0.1/admin/. The first user already exists, welcome to the Django admin panel.
-    
-    Django is still in Debug mode! You can work in your IDE, write code, and immediately see changes inside the container. However, you are currently using Traefik and Postgres. You can also add Redis or MongoDB, and all of this will work in your development environment. This is very convenient.
-    
-    > Between Docker Compose restarts, your database data and media files uploaded to the server will be preserved because they are stored in special volumes that are not deleted when containers are restarted.
-    
-    Want to delete everything? No problem, the command below will stop all containers, remove them and their images.
-    ```console
-    docker compose down --remove-orphans --rmi local
-    ```
-    
-    To delete the Postgre database as well, add the `-v` flag to the command:
-    ```console
-    docker compose down --remove-orphans --rmi local -v
-    ```
+Enjoy watching the lines run in the terminal 🖥️   
+And after a few seconds, open your browser at http://127.0.0.1/admin/. The first user already exists, welcome to the Django admin panel.
+
+Django is still in Debug mode! You can work in your IDE, write code, and immediately see changes inside the container. However, you are currently using Traefik and Postgres. You can also add Redis or MongoDB, and all of this will work in your development environment. This is very convenient.
+
+> Between Docker Compose restarts, your database data and media files uploaded to the server will be preserved because they are stored in special volumes that are not deleted when containers are restarted.
+
+Want to delete everything? No problem, the command below will stop all containers, remove them and their images.
+```console
+docker compose down --remove-orphans --rmi local
+```
+
+To delete the Postgre database as well, add the `-v` flag to the command:
+```console
+docker compose down --remove-orphans --rmi local -v
+```
 
 ### Django settings
 
@@ -124,17 +124,17 @@ For the Let's Encrypt HTTP challenge you will need:
 #### Steps on a server
 
 1. Clone the repository on your host and go to the `django-docker-template` directory:
-    ```console
-    git clone https://github.com/amerkurev/django-docker-template.git
-    cd django-docker-template
-    ```
+```console
+git clone https://github.com/amerkurev/django-docker-template.git
+cd django-docker-template
+```
 
 2. Configure as described in the [Django settings](#django-settings) section or leave everything as is.
 
 3. Run, specifying your domain:
-    ```console
-    MY_DOMAIN=your.domain.com docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
-    ```
+```console
+MY_DOMAIN=your.domain.com docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
+```
 
 It will take a few seconds to start the database, migrate, collect static files, and obtain a Let's Encrypt certificate. So wait a little and open https://your.domain.com in your browser. Your server is ready to work 🏆 
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@ docker compose -f docker-compose.debug.yml up -d
 Enjoy watching the lines run in the terminal 🖥️   
 And after a few seconds, open your browser at http://127.0.0.1/admin/. The first user already exists, welcome to the Django admin panel.
 
+7. With the containers running, you can run manage.py commands using this format:
+
+- Run test suite
+ ```console
+ docker-compose exec django python manage.py test
+ ```
+- Make migrations
+ ```console
+ docker-compose exec django python manage.py makemigrations
+ ```
+- Create superuser
+ ```console
+ docker-compose exec django python manage.py createsuperuser
+ ```
+- Access the Django shell
+ ```console
+ docker-compose exec django python manage.py shell
+ ```
+- Check the project for deployment issues
+ ```console
+ docker-compose exec django python manage.py check --deploy
+ ```
+
 Django is still in Debug mode! You can work in your IDE, write code, and immediately see changes inside the container. However, you are currently using Traefik and Postgres. You can also add Redis or MongoDB, and all of this will work in your development environment. This is very convenient.
 
 > Between Docker Compose restarts, your database data and media files uploaded to the server will be preserved because they are stored in special volumes that are not deleted when containers are restarted.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker run -it --rm -v sqlite:/sqlite django-docker-template:master python manag
 
 6. Start all services locally (Postgres, Gunicorn, Traefik) using docker-compose:
 ```console
-docker compose -f docker-compose.debug.yml up
+docker compose -f docker-compose.debug.yml up -d
 ```
 
 Enjoy watching the lines run in the terminal 🖥️   
@@ -120,7 +120,7 @@ cd django-docker-template
 
 3. Run, specifying your domain:
 ```console
-MY_DOMAIN=your.domain.com docker compose -f docker-compose.yml -f docker-compose.tls.yml up
+MY_DOMAIN=your.domain.com docker compose -f docker-compose.yml -f docker-compose.tls.yml up -d
 ```
 
 It will take a few seconds to start the database, migrate, collect static files, and obtain a Let's Encrypt certificate. So wait a little and open https://your.domain.com in your browser. Your server is ready to work 🏆 


### PR DESCRIPTION
- Run docker-compose in detached mode (run containers in the background) so that the user does not have to open a new terminal instance to keep developing or try to push the process to the background

- Add documentation for running commands against manage.py

- Pass the build flag to rebuild the container if the user adds new dependencies to requirements.txt - which will happen because this is a barebones starter 