### PR TITLE
Hashing for safe create command

### DIFF
--- a/website/setup/management/commands/safecreatesuperuser.py
+++ b/website/setup/management/commands/safecreatesuperuser.py
@@ -7,6 +7,7 @@ import os
 
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
+from django.contrib.auth.hashers import make_password
 
 
 class Command(BaseCommand):
@@ -33,7 +34,7 @@ class Command(BaseCommand):
 
         defaults = {
             "email": options["email"],
-            "password": options["password"],
+            "password": make_password(options["password"]),
             "is_superuser": True,
             "is_staff": True,
         }


### PR DESCRIPTION
A fix for #20;

current:
```shell
/usr/src/website # python manage.py dumpdata auth.user
[{
  "model": "auth.user",
  "pk": 1,
  "fields": {
    "password": "admin",
    "last_login": null, 
    "is_superuser": true,
    "username": "admin",
    "first_name": "",
    "last_name": "",
    "email": "admin@example.com",
    "is_staff": true,
    "is_active": true,
    "date_joined": "2024-06-03T21:27:21.811Z",
    "groups": [],
    "user_permissions": []
  }
}]
```

this PR:

```shell
/usr/src/website # python manage.py dumpdata auth.user
[{
  "model": "auth.user",
  "pk": 1,
  "fields": {
    "password": "pbkdf2_sha256$600000$rU94cxPQuV2V4Vl2kForP4$W6ryPcY16+wp7z3QRe3gAibChUgv2/DV0dXWSQokhZ8=",
    "last_login": 2024-06-03T21:48:14.076Z, 
    "is_superuser": true,
    "username": "admin",
    "first_name": "",
    "last_name": "",
    "email": "admin@example.com",
    "is_staff": true,
    "is_active": true,
    "date_joined": "2024-06-03T21:47:32.986Z",
    "groups": [],
    "user_permissions": []
  }
}]
```
